### PR TITLE
Forward params_file launch argument through ben_core_launch.py

### DIFF
--- a/launch/ben_core_launch.py
+++ b/launch/ben_core_launch.py
@@ -23,6 +23,7 @@ def generate_launch_description():
   odom_frame = LaunchConfiguration('odom_frame')
 
   is_simulator = LaunchConfiguration('is_simulator')
+  params_file = LaunchConfiguration('params_file')
 
   namespace_arg = DeclareLaunchArgument(
     "namespace", default_value=TextSubstitution(text="ben")
@@ -48,6 +49,16 @@ def generate_launch_description():
     "is_simulator", default_value=TextSubstitution(text="false")
   )
 
+  params_file_arg = DeclareLaunchArgument(
+    "params_file",
+    default_value=PathJoinSubstitution([
+      FindPackageShare('ben_project11'),
+      'config',
+      'nav2_params.yaml',
+    ]),
+    description='Full path to the ROS2 parameters file for nav2 nodes',
+  )
+
 
 
   return LaunchDescription([
@@ -58,6 +69,7 @@ def generate_launch_description():
     map_frame_arg,
     odom_frame_arg,
     is_simulator_arg,
+    params_file_arg,
     IncludeLaunchDescription(
       PythonLaunchDescriptionSource(
         PathJoinSubstitution([
@@ -140,6 +152,7 @@ def generate_launch_description():
         'use_namespace': 'true',
         'use_composition': 'False',
         'use_respawn': 'True',
+        'params_file': params_file,
       }.items()
     )
   ])


### PR DESCRIPTION
## Summary

- Forward the `params_file` launch argument from `ben_core_launch.py` to
  `nav2_bringup_launch.py`, allowing callers to override the nav2 params file
- Default remains `ben_project11/config/nav2_params.yaml` — no behavior change
  for existing users

## Motivation

End-to-end simulation tests (rolker/unh_marine_simulation#11) need smaller costmap
dimensions to avoid OOM in test environments. The default 5000x5000 global costmap
causes `std::bad_alloc` in `controller_server`. With this change,
`sim_robot_launch.py` can forward a test-specific params file with reduced costmap
size.

## Test plan

- [x] `colcon build --packages-select ben_project11` passes
- [ ] Verify existing launch behavior unchanged (default params_file resolves to
  `ben_project11/config/nav2_params.yaml`)
- [ ] Verify custom params_file can be passed through from sim_robot_launch.py

Closes #3

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
