### PR TITLE
feat: enable tide-aware costmap navigation for sim testing

### DIFF
--- a/config/ben.yaml
+++ b/config/ben.yaml
@@ -113,6 +113,12 @@
       windup_limit: 1.0
       max_dt: 1.0
 
+/**/chart_datum:
+  ros__parameters:
+    map_frame: ben/map
+    chart_datum_frame: ben/chart_datum
+    base_frame: ben/base_link
+
 /**/s57_grids:
   ros__parameters:
     map_frame: ben/map

--- a/config/nav2_params.yaml
+++ b/config/nav2_params.yaml
@@ -80,7 +80,7 @@ local_costmap:
     ros__parameters:
       update_frequency: 5.0
       publish_frequency: 2.0
-      global_frame: <tf_prefix>/odom
+      global_frame: <tf_prefix>/map_tide
       robot_base_frame: <tf_prefix>/base_link
       rolling_window: true
       width: 350
@@ -99,6 +99,7 @@ local_costmap:
         maximum_caution_depth: 2.5
         overhead_clearance: 5.0
         update_timeout: 0.15
+        chart_datum_frame: <tf_prefix>/chart_datum
         s57_grids_namespace: <robot_namespace>/s57
         #get_datasets_service: <robot_namespace>/s57/get_datasets
 
@@ -110,7 +111,7 @@ global_costmap:
     ros__parameters:
       update_frequency: 1.0
       publish_frequency: 1.0
-      global_frame: <tf_prefix>/map
+      global_frame: <tf_prefix>/map_tide
       robot_base_frame: <tf_prefix>/base_link
       robot_radius: 3.0
       footprint: "[[2.65, 0], [2.6, 0.1], [2.4, 0.4], [1.9, 0.6], [1.0, 0.85], [-1.3, 0.85], [-1.35, 0.4], [-1.6, 0.35], [-1.6, -0.35], [-1.35, -0.4], [-1.3, -0.85], [1.0, -0.85], [1.9, -0.6], [2.4, -0.4], [2.6, -0.1], [2.65, 0]]"
@@ -127,6 +128,7 @@ global_costmap:
         maximum_caution_depth: 2.5
         overhead_clearance: 5.0
         update_timeout: 0.75
+        chart_datum_frame: <tf_prefix>/chart_datum
         s57_grids_namespace: <robot_namespace>/s57
         get_datasets_service: <robot_namespace>/s57/get_datasets
       inflation_layer:

--- a/launch/ben_core_launch.py
+++ b/launch/ben_core_launch.py
@@ -9,6 +9,7 @@ from launch.substitutions import PathJoinSubstitution
 from launch.substitutions import TextSubstitution
 from launch_ros.actions import Node
 from launch_ros.actions import PushROSNamespace
+from launch_ros.actions import SetParameter
 from launch_ros.actions import SetParametersFromFile
 from launch_ros.substitutions import FindPackageShare
 
@@ -131,6 +132,30 @@ def generate_launch_description():
             {'map_frame': map_frame},
             {'odom_frame': odom_frame}
           ],
+        ),
+        # Sea surface estimator: publishes map → map_tide TF
+        SetParameter(
+          name='sea_surface_frame',
+          value=PathJoinSubstitution([tf_prefix, 'map_tide'])
+        ),
+        IncludeLaunchDescription(
+          PythonLaunchDescriptionSource(
+            PathJoinSubstitution([
+              FindPackageShare('mru_transform'),
+              'launch',
+              'sea_surface_estimator_launch.py'
+            ])
+          ),
+        ),
+        # Chart datum: publishes map → chart_datum TF (MLLW offset)
+        IncludeLaunchDescription(
+          PythonLaunchDescriptionSource(
+            PathJoinSubstitution([
+              FindPackageShare('mru_transform'),
+              'launch',
+              'chart_datum_launch.py'
+            ])
+          ),
         ),
         GroupAction(
           actions=[


### PR DESCRIPTION
## Summary

- Switch local and global costmap `global_frame` to `map_tide` (tidal reference frame)
- Add `chart_datum_frame` parameter to both costmap `chart_layer` sections so s57_layer applies tide offset to chart depths
- Launch `sea_surface_estimator` (`map → map_tide` TF) and `chart_datum_node` (`map → chart_datum` TF via PROJ/VDatum) in `ben_core_launch.py`
- Add chart_datum node frame params (`map_frame`, `chart_datum_frame`, `base_frame`) to `ben.yaml`

Depth thresholds unchanged (1.0m min, 2.5m caution, 5.0m overhead). Matches the tide-aware pipeline already running on BizzyBoat.

Closes #14

## Test plan

- [ ] Launch Ben in Gazebo sim with tide model enabled (requires rolker/unh_marine_simulation#55)
- [ ] Verify `map_tide` and `chart_datum` TF frames are published
- [ ] Verify costmap updates reflect tide offset changes
- [ ] Confirm nav2 planner operates correctly with `map_tide` global frame

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
