### PR TITLE
fix: add sea_surface_frame to S57 costmap layer config

### DIFF
--- a/config/nav2_params.yaml
+++ b/config/nav2_params.yaml
@@ -100,6 +100,7 @@ local_costmap:
         overhead_clearance: 5.0
         update_timeout: 0.15
         chart_datum_frame: <tf_prefix>/chart_datum
+        sea_surface_frame: <tf_prefix>/map_tide
         s57_grids_namespace: <robot_namespace>/s57
         #get_datasets_service: <robot_namespace>/s57/get_datasets
 
@@ -129,6 +130,7 @@ global_costmap:
         overhead_clearance: 5.0
         update_timeout: 0.75
         chart_datum_frame: <tf_prefix>/chart_datum
+        sea_surface_frame: <tf_prefix>/map_tide
         s57_grids_namespace: <robot_namespace>/s57
         get_datasets_service: <robot_namespace>/s57/get_datasets
       inflation_layer:


### PR DESCRIPTION
## Summary

- Add `sea_surface_frame: <tf_prefix>/map_tide` to both local and global costmap S57 chart_layer configs
- Fixes tide offset lookup failure where the layer looked for `map_tide` but the actual TF frame is `ben/map_tide`

Closes #16

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
