### PR TITLE
fix(nav2): bump local chart_layer update_timeout 0.15 -> 0.2 s

### DIFF
--- a/config/nav2_params.yaml
+++ b/config/nav2_params.yaml
@@ -98,7 +98,7 @@ local_costmap:
         minimum_depth: 1.0
         maximum_caution_depth: 2.5
         overhead_clearance: 5.0
-        update_timeout: 0.15
+        update_timeout: 0.2
         chart_datum_frame: <tf_prefix>/chart_datum
         sea_surface_frame: <tf_prefix>/map_tide
         s57_grids_namespace: <robot_namespace>/s57


### PR DESCRIPTION
## Summary

- Bump `local_costmap.chart_layer.update_timeout` from `0.15` to `0.2` s in `config/nav2_params.yaml`.
- At the local costmap's 5 Hz update rate, 0.2 s stays within the per-cycle period (1/5 Hz = 0.2 s) so the cycle rate doesn't drop. Gives the chart layer ~33 % more budget per pass to make progress on tile regeneration.
- Conservative bump intended to ride alongside rolker/s57_tools#15 / PR #16 (cache-invalidation reductions). Larger values would require also lowering `update_frequency` to avoid cycle overrun.

Global costmap (`update_timeout: 0.75`) is unchanged — its 1 Hz rate already gives a generous 75 % per-cycle budget.

Closes #18. Related: rolker/unh_marine_navigation#19, rolker/s57_tools#15.

## Test plan

- [x] yaml-only change, no build needed.
- [ ] Field validation: confirm next BizzyBoat survey doesn't show the inter-line cold-cache stall pattern from 2026-04-21 (controller_server costmap timeout 2 s after goal accepted).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
