### PR TITLE
fix(sim): override S57 chart_layer tide threshold to 0.05 m in sim

### DIFF
--- a/config/ben_sim.yaml
+++ b/config/ben_sim.yaml
@@ -32,3 +32,18 @@
               nav_position: {source: sensors/nav/position}
               nav_orientation: {source: sensors/nav/orientation}
               nav_velocity: {source: sensors/nav/velocity}
+
+# S57 chart layer tide threshold — sim runs with tide_speed_factor=10
+# move tide ~10× real-time, so the field-appropriate 1 cm threshold
+# fires ~10× as often. 5 cm restores roughly real-time-equivalent
+# invalidation cadence and avoids costmap-stall planner aborts.
+# Requires rolker/s57_tools#17 (tide_invalidate_threshold parameter).
+/**/local_costmap/local_costmap:
+  ros__parameters:
+    chart_layer:
+      tide_invalidate_threshold: 0.05
+
+/**/global_costmap/global_costmap:
+  ros__parameters:
+    chart_layer:
+      tide_invalidate_threshold: 0.05


### PR DESCRIPTION
## Summary

Override `chart_layer.tide_invalidate_threshold` to `0.05` m for both `local_costmap` and `global_costmap` in `ben_sim.yaml` (sim-only, already gated by `is_simulator` in `ben_core_launch.py`).

Field `nav2_params.yaml` stays at the default `0.01` m for safety.

Closes #20. **Requires** rolker/s57_tools#17 / PR #18 to land first (parameter declaration on S57Layer). Related: rolker/unh_marine_navigation#19.

## Why

`sim_robot_launch.py` defaults `tide_speed_factor=10` → simulated tide moves 10× real-time. The 1 cm field-appropriate threshold then fires ~10× as often (~every 8 s) and causes costmap stalls. Bag analysis from sim run on deadpool (2026-04-21T22:03:55) showed 15 tide updates in 125 s correlating with 7 `Costmap timed out waiting for update` planner aborts and a `Control loop missed its desired rate of 5.0000 Hz. Current loop rate is 2.0382 Hz` controller_server warning.

## Test plan

- [x] yaml-only change, no build needed.
- [x] **Verified end-to-end on deadpool** with both PRs overlaid: log shows `Tide correction enabled: ... invalidate threshold 0.05 m` for both `local_costmap` and `global_costmap`. Tide updates dropped from 6 in 77 s (default 0.01 m) to 2 in 77 s (override 0.05 m) — 3× reduction in the same run duration, restoring roughly real-time-equivalent cadence.
- [ ] Field validation: confirm next BizzyBoat outing still sees ~1 cm tide steps in field (no behavior change vs current — `ben.yaml` and `nav2_params.yaml` are untouched).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
