### PR TITLE
fix(s57): enable grid precompute on s57_grids

### DIFF
--- a/config/ben.yaml
+++ b/config/ben.yaml
@@ -123,6 +123,14 @@
   ros__parameters:
     map_frame: ben/map
 
+    # Precompute on first available pose: when TF (map → robot_base_frame)
+    # first becomes available, queue all charts within precompute_radius
+    # for std::async processing so the costmap layer's first get_datasets
+    # call finds them already cached or close to ready. Cuts cold-cache
+    # startup latency. Requires rolker/s57_tools#19.
+    robot_base_frame: ben/base_link
+    precompute_radius: 5000.0
+
     robot:
       frame_id: ben/base_link
       minimum_depth: 0.0


### PR DESCRIPTION
## Summary

Set `robot_base_frame: ben/base_link` and `precompute_radius: 5000.0` on `/**/s57_grids` in `config/ben.yaml`. Once TF first publishes the boat's pose, `s57_grids_node` queues all overlapping charts for `std::async` processing — by the time the costmap layer's first `get_datasets` request fires, grids are either already cached or close to ready.

Closes #22. **Requires** rolker/s57_tools#19 / PR #20 (which adds the parameters). No effect / no harm before that lands; unknown parameters are silently ignored.

## Test plan

- [x] yaml-only change.
- [x] Verified end-to-end on deadpool sim 2026-04-22 (with the same parameter values via install-only override): `Precompute: queued 10 of 10 charts within 5000 m of (43.0734, -70.7106).` ~0.6 s after node activation.
- [ ] Field validation: confirm next ben outing shows the precompute log lines from `s57_grids_node` shortly after activation, and that first plan after activation is faster than current baseline.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
