### PR TITLE
Fix Hover Marker rviz type so rosbag2 can record /ben/hover_visualization

### DIFF
--- a/config/ben.rviz
+++ b/config/ben.rviz
@@ -492,7 +492,7 @@ Visualization Manager:
         Reliability Policy: Reliable
         Value: /ben/unsmoothed_plan
       Value: true
-    - Class: rviz_default_plugins/Marker
+    - Class: rviz_default_plugins/MarkerArray
       Enabled: true
       Name: Hover Marker
       Namespaces:


### PR DESCRIPTION
## Summary

Fixes the `ros2 bag record` failure on `/<ns>/hover_visualization`:

```
[ROSBAG2_TRANSPORT]: Topic '/ben/hover_visualization' has more than one type associated. Only topics with one type are supported
```

The hover behavior publisher (`behavior_server`) emits `visualization_msgs/msg/MarkerArray`, but the **"Hover Marker"** display in `config/ben.rviz` was class `rviz_default_plugins/Marker` — subscribing as `Marker`. That put a second type announcement on the topic name, and rosbag2 enforces type-uniqueness across **all** endpoints (publishers and subscribers), so it rejected the topic.

## Change

`config/ben.rviz`: "Hover Marker" display `rviz_default_plugins/Marker` → `rviz_default_plugins/MarkerArray`. (The "Path Follower MarkerArray" display in the same file was already correct and is the precedent.)

## Why CAMP needs no change

CAMP's marker subscription is type-adaptive (`markers_manager.cpp` reads the type from the ROS graph; `Marker` sorts before `MarkerArray`, so it was mirroring rviz's wrong type). With rviz corrected, `MarkerArray` is the only type on the graph and CAMP subscribes as `MarkerArray` automatically.

## Not related to unh_marine_navigation #42/#48

Those fixed publisher churn and are working — `ros2 topic info` shows publisher count 1, type `MarkerArray`. This is a separate subscriber-side type mismatch.

## Verification

- [x] Root cause confirmed live via `ros2 topic info /ben/hover_visualization -v` (two types: `Marker` from rviz/camp subs, `MarkerArray` from publisher).
- [ ] Post-merge: relaunch with the corrected rviz config, confirm `ros2 topic info` reports a single type `MarkerArray` and `ros2 bag record /ben/hover_visualization` captures messages with no error spam.

Closes #26

---
**Authored-By**: ``
**Model**: ``
